### PR TITLE
Adjust decodeQuotedPrintable function for utf-8 handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -307,9 +307,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // Replace = followed by a newline with nothing
         str = str.replace(/=[\r\n]+/g, '');
         // Replace =XX with the corresponding character
-        return str.replace(/=([0-9A-F]{2})/gi, (match, p1) => {
-            return String.fromCharCode(parseInt(p1, 16));
-        });
+        return decodeURIComponent(escape(
+	    str.replace(/=([0-9A-F]{2})/gi, (match, p1) => {
+                return String.fromCharCode(parseInt(p1, 16));
+        })));
     }
 
     function escapeRegExp(string) {


### PR DESCRIPTION
Existing function converted the quoted to individual characters, but they were not being rendered as the escaped character intended in many instances. For example a utf-8 single quote ("’") in the mht is converted to =E2=80=99 in MIME, but when the code converted it to bytecode/characters, it rendered as "â".  The added code will resolve the byte sequencing correctly without needing to add a lot of logic to determine the correct encoding for the expected result as that is within the built-in function.